### PR TITLE
feat(drivers) Motor driver TB6612FNG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ SOURCES_WITH_HEADERS = src/drivers/io.c \
 					src/common/trace.c \
 					src/drivers/ir_remote.c \
 					src/common/enum_to_string.c \
+					src/drivers/pwm.c \
+					src/drivers/tb6612fng.c \
 
 
 SOURCES = $(MAIN_FILE) \

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ SOURCES_WITH_HEADERS = src/drivers/io.c \
 					src/common/enum_to_string.c \
 					src/drivers/pwm.c \
 					src/drivers/tb6612fng.c \
+					src/app/drive.c \
 
 
 SOURCES = $(MAIN_FILE) \

--- a/src/app/drive.c
+++ b/src/app/drive.c
@@ -1,0 +1,104 @@
+#include "drive.h"
+#include <assert.h>
+#include <stdint.h>
+#include "../drivers/tb6612fng.h"
+#include <stdbool.h>
+#include "../common/defines.h"
+#include "../common/assert_handler.h"
+
+struct drive_speeds
+{
+    uint8_t left;
+    uint8_t right;
+};
+
+/* Drive directions come in pair (e.g. FORWARD and REVERSE, ROTATE_LEFT and ROTATE_RIGHT).
+ * To save flash space and minimize typos, only save the speeds for one direction (primary),
+ * and create a macro to get the corresponding primary direction for every direction and
+ * inverse the speeds when its not the primary direction. */
+#define DRIVE_PRIMARY_DIRECTION(dir) (dir - MODULO_2(dir))
+static_assert(DRIVE_PRIMARY_DIRECTION(DRIVE_DIR_REVERSE) == DRIVE_DIR_FORWARD);
+static const struct drive_speeds drive_primary_speeds[][4] =
+{
+    [DRIVE_DIR_FORWARD] = {
+        [DRIVE_SPEED_SLOW] = {25, 25},
+        [DRIVE_SPEED_MEDIUM] = {45, 45},
+        [DRIVE_SPEED_FAST] = {55, 55},
+        [DRIVE_SPEED_MAX] = {100, 100},
+    },
+    [DRIVE_DIR_ROTATE_LEFT] =
+    {
+        [DRIVE_SPEED_SLOW] = {-25, 25},
+        [DRIVE_SPEED_MEDIUM] = {-50, 50},
+        [DRIVE_SPEED_FAST] = {-60, 60},
+        [DRIVE_SPEED_MAX] = {-100, 100},
+    },
+    [DRIVE_DIR_ARCTURN_SHARP_LEFT] =
+    {
+        [DRIVE_SPEED_SLOW] = {-10, 25},
+        [DRIVE_SPEED_MEDIUM] = {-10, 50},
+        [DRIVE_SPEED_FAST] = {-25, 75},
+        [DRIVE_SPEED_MAX] = {-20, 100},
+    },
+    [DRIVE_DIR_ARCTURN_MID_LEFT] =
+    {
+        [DRIVE_SPEED_SLOW] = {15, 30},
+        [DRIVE_SPEED_MEDIUM] = {25, 50},
+        [DRIVE_SPEED_FAST] = {35, 70},
+        [DRIVE_SPEED_MAX] = {50, 100},
+    },
+    [DRIVE_DIR_ARCTURN_WIDE_LEFT] =
+    {
+        [DRIVE_SPEED_SLOW] = {20, 25},
+        [DRIVE_SPEED_MEDIUM] = {40, 50},
+        [DRIVE_SPEED_FAST] = {60, 70},
+        [DRIVE_SPEED_MAX] = {85, 100},
+    },
+};
+
+static void drive_inverse_speeds(int8_t *speed_left, int8_t *speed_right)
+{
+    if (*speed_left == *speed_right) {
+        *speed_left = -*speed_left;
+        *speed_right = -*speed_right;
+    } else {
+        // swap
+        const uint8_t tmp = *speed_right;
+        *speed_right = *speed_left;
+        *speed_left = tmp;
+    }
+}
+
+void drive_set(drive_dir_e direction, drive_speed_e speed)
+{
+    drive_dir_e primary_direction = DRIVE_PRIMARY_DIRECTION(direction);
+    int8_t speed_left = drive_primary_speeds[primary_direction][speed].left;
+    int8_t speed_right = drive_primary_speeds[primary_direction][speed].right;
+    if (direction != primary_direction) {
+        drive_inverse_speeds(&speed_left, &speed_right);
+    }
+    ASSERT(speed_left != 0 && speed_right != 0);
+    const tb6612fng_mode_e mode_left =
+        speed_left > 0 ? TB6612FNG_MODE_FORWARD : TB6612FNG_MODE_REVERSE;
+    tb6612fng_set_mode(TB6612FNG_LEFT, mode_left);
+    const tb6612fng_mode_e mode_right =
+        speed_right > 0 ? TB6612FNG_MODE_FORWARD : TB6612FNG_MODE_REVERSE;
+    tb6612fng_set_mode(TB6612FNG_RIGHT, mode_right);
+    tb6612fng_set_pwm(TB6612FNG_LEFT, ABS(speed_left));
+    tb6612fng_set_pwm(TB6612FNG_RIGHT, ABS(speed_right));
+}
+
+void drive_stop(void)
+{
+    tb6612fng_set_mode(TB6612FNG_LEFT, TB6612FNG_MODE_STOP);
+    tb6612fng_set_mode(TB6612FNG_RIGHT, TB6612FNG_MODE_STOP);
+    tb6612fng_set_pwm(TB6612FNG_LEFT, 0);
+    tb6612fng_set_pwm(TB6612FNG_RIGHT, 0);
+}
+
+static bool initialized = false;
+void drive_init(void)
+{
+    ASSERT(!initialized);
+    tb6612fng_init();
+}

--- a/src/app/drive.h
+++ b/src/app/drive.h
@@ -1,0 +1,32 @@
+#ifndef DRIVE_H
+#define DRIVE_H
+
+// A coarser drive interface for controlling the motors from the application code
+
+typedef enum
+{
+    DRIVE_DIR_FORWARD,
+    DRIVE_DIR_REVERSE,
+    DRIVE_DIR_ROTATE_LEFT,
+    DRIVE_DIR_ROTATE_RIGHT,
+    DRIVE_DIR_ARCTURN_SHARP_LEFT,
+    DRIVE_DIR_ARCTURN_SHARP_RIGHT,
+    DRIVE_DIR_ARCTURN_MID_LEFT,
+    DRIVE_DIR_ARCTURN_MID_RIGHT,
+    DRIVE_DIR_ARCTURN_WIDE_LEFT,
+    DRIVE_DIR_ARCTURN_WIDE_RIGHT,
+} drive_dir_e;
+
+typedef enum
+{
+    DRIVE_SPEED_SLOW,
+    DRIVE_SPEED_MEDIUM,
+    DRIVE_SPEED_FAST,
+    DRIVE_SPEED_MAX
+} drive_speed_e;
+
+void drive_init(void);
+void drive_stop(void);
+void drive_set(drive_dir_e direction, drive_speed_e speed);
+
+#endif

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -45,11 +45,24 @@ static void assert_trace(uint16_t program_counter)
     uart_trace_assert(assert_string);
 }
 
+// Stop the motors when something unexpected happens (assert) to prevent damage
+static void assert_stop_motors(void)
+{
+
+    GPIO_OUTPUT_LOW(2, 4); // Left CC2 (sumo)
+    GPIO_OUTPUT_LOW(2, 5); // Left CC1 (sumo)
+    GPIO_OUTPUT_LOW(2, 7); // Right CC2 (sumo)
+    GPIO_OUTPUT_LOW(3, 7); // Right CC1 (sumo)
+    GPIO_OUTPUT_LOW(3, 5); // Left PWM (sumo)
+    GPIO_OUTPUT_LOW(3, 6); // Right PWM (sumo)
+}
+
 /* Minimize code dependency in this function to reduce the risk of accidently calling
  * a function with an assert in it, which would cause the assert_handler to be called
  * recursively until stack overflow. */
 void assert_handler(uint16_t program_counter)
 {
+    assert_stop_motors();
     BREAKPOINT
     assert_blink_led();
     assert_trace(program_counter);

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -8,6 +8,7 @@
 
 #define MODULO_2(x) (x & 1)
 #define IS_ODD(x) MODULO_2(x)
+#define ABS(x) ((x) >= 0 ? (x) : -(x))
 
 
 #define CYCLES_1MHZ (1000000u)

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -3,6 +3,7 @@
 
 #define UNUSED(x) (void)(x)
 #define SUPPRESS_UNUSED __attribute__((unused))
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 #define INTERRUPT_FUNCTION(vector) void __attribute__((interrupt(vector)))
 
 #define MODULO_2(x) (x & 1)

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -12,8 +12,6 @@
 #define IO_PIN_CNT_PER_PORT (8u)
 // Port 3 is not interrupt capable
 #define IO_INTERRUPT_PORT_CNT (2u)
-#define ARRAY_SIZE(array) (sizeof(array)/sizeof(array[0]))
-
 
 /* Be a little smart here about how to extract the port and pin bit
  * from the enum io_generic_e (and io_e). With compiler flag "-fshort-enums",

--- a/src/drivers/ir_remote.c
+++ b/src/drivers/ir_remote.c
@@ -6,6 +6,7 @@
 #include <msp430.h>
 #include <stdint.h>
 #include "io.h"
+#include <stdbool.h>
 
 #ifndef DISABLE_IR_REMOTE
 

--- a/src/drivers/pwm.c
+++ b/src/drivers/pwm.c
@@ -1,0 +1,130 @@
+#include "pwm.h"
+#include <assert.h>
+#include "../common/defines.h"
+#include "../common/assert_handler.h"
+#include "io.h"
+#include "../common/defines.h"
+#include <stdbool.h>
+#include <msp430.h>
+
+
+/* MSP430G2553 has no dedicated PWM, so use timer A0 to emulate
+ * hardware PWM. Each timer has three capture/compare channels
+ * (CC) and first channel must be sacrificed for setting the
+ * base period (TA0CCR). The two other channels are used for
+ * one PWM output each and duty cycle is set by setting the
+ * timer value (TA0CCR1 and TA0CCR2). The CC outputs are muxed
+ * to corresponding IO pins (see io.h).
+ *
+ * Example (one period):
+ * -----------------_____________ // CC output
+ * <----TA0CCRx---->              // Duty cycle
+ * <----------TA0CCR0-----------> // Base period
+ *
+ * Set the base frequency to 20000 Hz because with SMCLK of 16 MHz it
+ * gives a base period of 100 ticks, which means the duty cycle
+ * percent corresponds to the TA0CCRx directly without any conversion.
+ * 20 kHz also gives stable motor behaviour. */
+#define PWM_TIMER_FREQ_HZ (SMCLK / TIMER_INPUT_DIVIDER_3)
+#define PWM_PERIOD_FREQ_HZ (20000)
+#define PWM_PERIOD_TICKS (PWM_TIMER_FREQ_HZ / PWM_PERIOD_FREQ_HZ)
+static_assert(PWM_PERIOD_TICKS == 100, "Expect 100 ticks per period");
+// Timer counts from 0, so should decrement by 1
+#define PWM_TA0CCR0 (PWM_PERIOD_TICKS - 1)
+
+/* -cctl: A constant pointer to a volatile unsigned integer,
+representing the control register for the PWM channel.
+-ccr: A constant pointer to a volatile unsigned integer, 
+representing the capture/compare register for the PWM channel*/
+struct pwm_channel_cfg
+{
+    bool enabled;
+    volatile unsigned int *const cctl;
+    volatile unsigned int *const ccr;
+};
+
+static struct pwm_channel_cfg pwm_cfgs[] = {
+    [PWM_TB6612FNG_LEFT] = { .enabled = false, .cctl = &TA0CCTL1, .ccr = &TA0CCR1 },
+    [PWM_TB6612FNG_RIGHT] = { .enabled = false, .cctl = &TA0CCTL2, .ccr = &TA0CCR2 },
+};
+
+static bool pwm_all_channels_disabled(void)
+{
+    for (uint8_t ch = 0; ch < ARRAY_SIZE(pwm_cfgs); ch++) {
+        if (pwm_cfgs[ch].enabled) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool pwm_enabled = false;
+static void pwm_enable(bool enable)
+{
+    if (pwm_enabled != enable) {
+        /* MC_0: Stop
+         * MC_1: Count to TACCR0 */
+        TA0CTL = (TA0CTL & ~TIMER_MC_MASK) + TACLR + (enable ? MC_1 : MC_0);
+        pwm_enabled = enable;
+    }
+}
+static void pwm_channel_enable(pwm_e pwm, bool enable)
+{
+    if (pwm_cfgs[pwm].enabled != enable) {
+        /* OUTMOD_7: Reset/Set
+         * OUTMOD_0: Off */
+        *pwm_cfgs[pwm].cctl = enable ? OUTMOD_7 : OUTMOD_0;
+        pwm_cfgs[pwm].enabled = enable;
+        if (enable) {
+            pwm_enable(true);
+        } else if (pwm_all_channels_disabled()) {
+            pwm_enable(false);
+        }
+    }
+}
+
+static inline uint8_t pwm_scale_duty_cycle(uint8_t duty_cycle_percent)
+{
+    /* Battery is at ~8 V when fully charged and motors are 6 V max,
+     * so scale down the duty cycle by 25% to be within specs. This
+     * should never return 0. */
+    return duty_cycle_percent == 1 ? duty_cycle_percent : duty_cycle_percent * 3 / 4;
+}
+
+
+void pwm_set_duty_cycle(pwm_e pwm, uint8_t duty_cycle_percent)
+{
+    ASSERT(duty_cycle_percent <= 100);
+    const bool enable = duty_cycle_percent > 0;
+    if (enable) {
+        *pwm_cfgs[pwm].ccr = pwm_scale_duty_cycle(duty_cycle_percent);
+    }
+    pwm_channel_enable(pwm, enable);
+}
+
+static const struct io_config pwm_io_config = {
+    .select = IO_SELECT_ALT1,
+    .resistor = IO_RESISTOR_DISABLED,
+    .dir = IO_DIR_OUTPUT,
+    .out = IO_OUT_LOW,
+};
+
+static bool initialized = false;
+void pwm_init(void)
+{
+    ASSERT(!initialized);
+    struct io_config current_config;
+    io_get_current_config(IO_PWM_MOTORS_LEFT, &current_config);
+    ASSERT(io_config_compare(&current_config, &pwm_io_config));
+    io_get_current_config(IO_PWM_MOTORS_RIGHT, &current_config);
+    ASSERT(io_config_compare(&current_config, &pwm_io_config));
+
+    /* TASSEL_2: Clock source SMCLK
+     * ID_3: Input divider /8
+     * MC_0: Stopped. By default the count should be 0*/
+    TA0CTL = TASSEL_2 + ID_3 + MC_0;
+    // Set period
+    TA0CCR0 = PWM_TA0CCR0;
+
+    initialized = true;
+}

--- a/src/drivers/pwm.h
+++ b/src/drivers/pwm.h
@@ -1,0 +1,18 @@
+#ifndef PWM_H
+#define PWM_H
+
+// Driver that emulates hardware PWM with timer peripheral
+
+#include <stdint.h>
+// 2 channnels one for the left and right motor controller respectively
+typedef enum
+{
+    PWM_TB6612FNG_LEFT,
+    PWM_TB6612FNG_RIGHT
+} pwm_e;
+
+void pwm_init(void);
+// takes in the channel and the duty cycle.
+void pwm_set_duty_cycle(pwm_e pwm, uint8_t duty_cycle_percent);
+
+#endif // PWM_H

--- a/src/drivers/tb6612fng.c
+++ b/src/drivers/tb6612fng.c
@@ -1,0 +1,69 @@
+#include "tb6612fng.h"
+#include <stdbool.h>
+#include <assert.h>
+#include "io.h"
+#include "pwm.h"
+#include "../common/assert_handler.h"
+
+
+struct cc_pins
+{
+    io_e cc1;
+    io_e cc2;
+};
+
+static struct cc_pins tb6612fng_cc_pins[] = {
+    [TB6612FNG_LEFT] = { IO_MOTORS_LEFT_CC_1, IO_MOTORS_LEFT_CC_2 },
+    [TB6612FNG_RIGHT] = { IO_MOTORS_RIGHT_CC_1, IO_MOTORS_RIGHT_CC_2 },
+};
+
+void tb6612fng_set_mode(tb6612fng_e tb, tb6612fng_mode_e mode)
+{
+    switch (mode) {
+    case TB6612FNG_MODE_STOP:
+        io_set_out(tb6612fng_cc_pins[tb].cc1, IO_OUT_LOW);
+        io_set_out(tb6612fng_cc_pins[tb].cc2, IO_OUT_LOW);
+        break;
+    case TB6612FNG_MODE_FORWARD:
+        io_set_out(tb6612fng_cc_pins[tb].cc1, IO_OUT_HIGH);
+        io_set_out(tb6612fng_cc_pins[tb].cc2, IO_OUT_LOW);
+        break;
+    case TB6612FNG_MODE_REVERSE:
+        io_set_out(tb6612fng_cc_pins[tb].cc1, IO_OUT_LOW);
+        io_set_out(tb6612fng_cc_pins[tb].cc2, IO_OUT_HIGH);
+        break;
+    }
+}
+
+static_assert(TB6612FNG_LEFT == (int)PWM_TB6612FNG_LEFT, "Enum mismatch");
+static_assert(TB6612FNG_RIGHT == (int)PWM_TB6612FNG_RIGHT, "Enum mismatch");
+void tb6612fng_set_pwm(tb6612fng_e tb, uint8_t duty_cycle)
+{
+    pwm_set_duty_cycle((pwm_e)tb, duty_cycle);
+}
+static void tb6612fng_assert_io_cfg(void)
+{
+    static const struct io_config cc_io_config = {
+        .select = IO_SELECT_GPIO,
+        .resistor = IO_RESISTOR_DISABLED,
+        .dir = IO_DIR_OUTPUT,
+        .out = IO_OUT_LOW,
+    };
+    struct io_config current_config;
+    io_get_current_config(IO_MOTORS_LEFT_CC_1, &current_config);
+    ASSERT(io_config_compare(&current_config, &cc_io_config));
+    io_get_current_config(IO_MOTORS_LEFT_CC_2, &current_config);
+    ASSERT(io_config_compare(&current_config, &cc_io_config));
+    io_get_current_config(IO_MOTORS_RIGHT_CC_1, &current_config);
+    ASSERT(io_config_compare(&current_config, &cc_io_config));
+    io_get_current_config(IO_MOTORS_RIGHT_CC_2, &current_config);
+    ASSERT(io_config_compare(&current_config, &cc_io_config));
+}
+static bool initialized = false;
+void tb6612fng_init(void)
+{
+    ASSERT(!initialized);
+    tb6612fng_assert_io_cfg();
+    pwm_init();
+    initialized = true;
+}

--- a/src/drivers/tb6612fng.h
+++ b/src/drivers/tb6612fng.h
@@ -1,0 +1,25 @@
+#ifndef TB6612FNG_H
+#define TB6612FNG_H
+
+// Driver for motor driver TB6612FNG
+
+#include <stdint.h>
+
+typedef enum
+{
+    TB6612FNG_LEFT,
+    TB6612FNG_RIGHT
+} tb6612fng_e;
+
+typedef enum
+{
+    TB6612FNG_MODE_STOP,
+    TB6612FNG_MODE_FORWARD, // Clockwise (CC)
+    TB6612FNG_MODE_REVERSE, // Counterclockwise (CCW)
+} tb6612fng_mode_e;
+
+void tb6612fng_init(void);
+void tb6612fng_set_mode(tb6612fng_e tb, tb6612fng_mode_e mode);
+void tb6612fng_set_pwm(tb6612fng_e tb, uint8_t duty_cycle);
+
+#endif

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -10,6 +10,7 @@
 #include "../drivers/pwm.h"
 #include "../drivers/tb6612fng.h"
 #include <msp430.h>
+#include "../app/drive.h"
 
 SUPPRESS_UNUSED
 static void test_setup(void)
@@ -228,6 +229,72 @@ static void test_tb6612fng(void)
             BUSY_WAIT_ms(1000);
         }
     }
+}
+
+SUPPRESS_UNUSED
+static void test_drive(void)
+{
+    test_setup();
+    trace_init();
+    drive_init();
+    ir_remote_init();
+    drive_speed_e speed = DRIVE_SPEED_SLOW;
+    drive_dir_e dir = DRIVE_DIR_FORWARD;
+    while (1) {
+        BUSY_WAIT_ms(100);
+        ir_cmd_e cmd = ir_remote_get_cmd();
+        switch (cmd) {
+        case IR_CMD_0:
+            drive_stop();
+            continue;
+        case IR_CMD_1:
+            speed = DRIVE_SPEED_SLOW;
+            break;
+        case IR_CMD_2:
+            speed = DRIVE_SPEED_MEDIUM;
+            break;
+        case IR_CMD_3:
+            speed = DRIVE_SPEED_FAST;
+            break;
+        case IR_CMD_4:
+            speed = DRIVE_SPEED_MAX;
+            break;
+        case IR_CMD_UP:
+            dir = DRIVE_DIR_FORWARD;
+            break;
+        case IR_CMD_DOWN:
+            dir = DRIVE_DIR_REVERSE;
+            break;
+        case IR_CMD_LEFT:
+            dir = DRIVE_DIR_ROTATE_LEFT;
+            break;
+        case IR_CMD_RIGHT:
+            dir = DRIVE_DIR_ROTATE_RIGHT;
+            break;
+        case IR_CMD_5:
+        case IR_CMD_6:
+        case IR_CMD_7:
+        case IR_CMD_8:
+        case IR_CMD_9:
+        case IR_CMD_STAR:
+        case IR_CMD_HASH:
+        case IR_CMD_OK:
+        case IR_CMD_NONE:
+            continue;
+        }
+        drive_set(dir, speed);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_assert_motors(void)
+{
+    test_setup();
+    drive_init();
+    drive_set(DRIVE_DIR_FORWARD, DRIVE_SPEED_MAX);
+    BUSY_WAIT_ms(3000);
+    ASSERT(0);
+    while(0) { }
 }
 
 int main()

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -7,6 +7,8 @@
 #include "../common/trace.h"
 #include "../common/enum_to_string.h"
 #include "../drivers/ir_remote.h"
+#include "../drivers/pwm.h"
+#include "../drivers/tb6612fng.h"
 #include <msp430.h>
 
 SUPPRESS_UNUSED
@@ -177,6 +179,54 @@ static void test_ir_remote(void)
     while (1) {
         TRACE("Command %s", ir_remote_cmd_to_string(ir_remote_get_cmd()));
         BUSY_WAIT_ms(250);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_pwm(void)
+{
+    test_setup();
+    trace_init();
+    pwm_init();
+    const uint8_t duty_cycles[] = { 100, 75, 50, 25, 1, 0 };
+    const uint16_t wait_time = 3000;
+    while (1) {
+        for (uint8_t i = 0; i < ARRAY_SIZE(duty_cycles); i++) {
+            TRACE("Set duty cycle to %d for %d ms", duty_cycles[i], wait_time);
+            pwm_set_duty_cycle(PWM_TB6612FNG_LEFT, duty_cycles[i]);
+            pwm_set_duty_cycle(PWM_TB6612FNG_RIGHT, duty_cycles[i]);
+            BUSY_WAIT_ms(wait_time);
+        }
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_tb6612fng(void)
+{
+    test_setup();
+    trace_init();
+    tb6612fng_init();
+    const tb6612fng_mode_e modes[] =
+    {
+        TB6612FNG_MODE_FORWARD,
+        TB6612FNG_MODE_REVERSE,
+        TB6612FNG_MODE_FORWARD,
+        TB6612FNG_MODE_REVERSE,
+    };
+    const uint8_t duty_cycles[] = { 45, 35, 25, 0 };
+    while (1) {
+        for (uint8_t i = 0; i < ARRAY_SIZE(duty_cycles); i++)
+        {
+            TRACE("Set mode %d and duty cycle %d", modes[i], duty_cycles[i]);
+            tb6612fng_set_mode(TB6612FNG_LEFT, modes[i]);
+            tb6612fng_set_mode(TB6612FNG_RIGHT, modes[i]);
+            tb6612fng_set_pwm(TB6612FNG_LEFT, duty_cycles[i]);
+            tb6612fng_set_pwm(TB6612FNG_RIGHT, duty_cycles[i]);
+            BUSY_WAIT_ms(3000);
+            tb6612fng_set_mode(TB6612FNG_LEFT, TB6612FNG_MODE_STOP);
+            tb6612fng_set_mode(TB6612FNG_RIGHT, TB6612FNG_MODE_STOP);
+            BUSY_WAIT_ms(1000);
+        }
     }
 }
 


### PR DESCRIPTION
Create a motor driver. Sumo has two motor drivers for each pair. It takes 3 inputs, one for CC input to control direction and one for PWM to control speed. Set the IO pin and use the existing PWM driver.