### PR TITLE
feat(drivers) ADC drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ SOURCES_WITH_HEADERS = src/drivers/io.c \
 					src/drivers/tb6612fng.c \
 					src/app/drive.c \
 					src/drivers/adc.c \
+					src/drivers/qre1113.c \
 
 
 SOURCES = $(MAIN_FILE) \

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ SOURCES_WITH_HEADERS = src/drivers/io.c \
 					src/app/drive.c \
 					src/drivers/adc.c \
 					src/drivers/qre1113.c \
+					src/app/line.c \
+					
 
 
 SOURCES = $(MAIN_FILE) \

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ SOURCES_WITH_HEADERS = src/drivers/io.c \
 					src/drivers/pwm.c \
 					src/drivers/tb6612fng.c \
 					src/app/drive.c \
+					src/drivers/adc.c \
 
 
 SOURCES = $(MAIN_FILE) \

--- a/src/app/line.c
+++ b/src/app/line.c
@@ -1,0 +1,54 @@
+#include "line.h"
+#include <stdbool.h>
+#include "../common/assert_handler.h"
+#include "../drivers/qre1113.h"
+
+// Based on readings from the sensors when they are above the white line
+#define LINE_DETECTED_VOLTAGE_THRESHOLD (700u)
+
+static bool initialized = false;
+void line_init(void)
+{
+    ASSERT(!initialized);
+    qre1113_init();
+    initialized = true;
+}
+
+line_e line_get(void)
+{
+    struct qre1113_voltages voltages;
+    qre1113_get_voltages(&voltages);
+    const bool front_left = voltages.front_left < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool front_right = voltages.front_right < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool back_left = voltages.back_left < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool back_right = voltages.back_right < LINE_DETECTED_VOLTAGE_THRESHOLD;
+
+    if (front_left) {
+        if (front_right) {
+            return LINE_FRONT;
+        } else if (back_left) {
+            return LINE_LEFT;
+        } else if (back_right) {
+            return LINE_DIAGONAL_LEFT;
+        } else {
+            return LINE_FRONT_LEFT;
+        }
+    } else if (front_right) {
+        if (back_right) {
+            return LINE_RIGHT;
+        } else if (back_left) {
+            return LINE_DIAGONAL_RIGHT;
+        } else {
+            return LINE_FRONT_RIGHT;
+        }
+    } else if (back_left) {
+        if (back_right) {
+            return LINE_BACK;
+        } else {
+            return LINE_BACK_LEFT;
+        }
+    } else if (back_right) {
+        return LINE_BACK_RIGHT;
+    }
+    return LINE_NONE;
+}

--- a/src/app/line.h
+++ b/src/app/line.h
@@ -1,0 +1,24 @@
+#ifndef LINE_H
+#define LINE_H
+
+// Detect the boundary line of the circular sumobot platform
+
+typedef enum
+{
+    LINE_NONE,
+    LINE_FRONT,
+    LINE_BACK,
+    LINE_LEFT,
+    LINE_RIGHT,
+    LINE_FRONT_LEFT,
+    LINE_FRONT_RIGHT,
+    LINE_BACK_LEFT,
+    LINE_BACK_RIGHT,
+    LINE_DIAGONAL_LEFT,
+    LINE_DIAGONAL_RIGHT
+} line_e;
+
+void line_init(void);
+line_e line_get(void);
+
+#endif // LINE_H

--- a/src/common/enum_to_string.c
+++ b/src/common/enum_to_string.c
@@ -44,4 +44,33 @@ const char *ir_remote_cmd_to_string(ir_cmd_e cmd)
     return "";
 }
 
+const char *line_to_string(line_e line)
+{
+    switch (line) {
+    case LINE_NONE:
+        return "NONE";
+    case LINE_FRONT:
+        return "FRONT";
+    case LINE_BACK:
+        return "BACK";
+    case LINE_FRONT_LEFT:
+        return "FRONT_LEFT";
+    case LINE_BACK_LEFT:
+        return "BACK_LEFT";
+    case LINE_FRONT_RIGHT:
+        return "FRONT_RIGHT";
+    case LINE_BACK_RIGHT:
+        return "BACK_RIGHT";
+    case LINE_LEFT:
+        return "LEFT";
+    case LINE_RIGHT:
+        return "RIGHT";
+    case LINE_DIAGONAL_LEFT:
+        return "DIAGONAL_LEFT";
+    case LINE_DIAGONAL_RIGHT:
+        return "DIAGONAL_RIGHT";
+    }
+    return "";
+}
+
 #endif

--- a/src/common/enum_to_string.h
+++ b/src/common/enum_to_string.h
@@ -2,7 +2,7 @@
 #define ENUM_TO_STRING_H
 
 #include "../drivers/ir_remote.h"
-
+#include "../app/line.h"
 
 #ifdef DISABLE_ENUM_STRINGS
 #include <stdint.h>
@@ -17,7 +17,7 @@ static inline const char *empty_func(uint8_t val)
 // #define drive_speed_to_string(speed) empty_func(speed)
 // #define enemy_pos_to_string(pos) empty_func(pos)
 // #define enemy_range_to_string(range) empty_func(range)
-// #define line_to_string(line) empty_func(line)
+#define line_to_string(line) empty_func(line)
 // #define state_to_string(state) empty_func(state)
 // #define state_event_to_string(event) empty_func(event)
 #else
@@ -26,7 +26,7 @@ const char *ir_remote_cmd_to_string(ir_cmd_e cmd);
 // const char *drive_speed_to_string(drive_speed_e speed);
 // const char *enemy_pos_to_string(enemy_pos_e pos);
 // const char *enemy_range_to_string(enemy_range_e range);
-// const char *line_to_string(line_e line);
+const char *line_to_string(line_e line);
 // const char *state_to_string(state_e state);
 // const char *state_event_to_string(state_event_e event);
 #endif

--- a/src/drivers/adc.c
+++ b/src/drivers/adc.c
@@ -1,0 +1,94 @@
+#include "adc.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include "io.h"
+#include <msp430.h>
+#include "../common/defines.h"
+#include "../common/assert_handler.h"
+
+/* Strategy:
+ * Setup ADC to sample a sequence of channels including the channels
+ * of interest. Interrupt after the sequence has been sampled and cache
+ * the sampled values and start a new round. Let the caller retrieve
+ * the latest values from the cache. Use DMA (DTC) and slow clock (ACLK)
+ * to reduce CPU involvement. */
+static volatile adc_channel_values_t adc_dtc_block;
+static volatile adc_channel_values_t adc_dtc_block_cache;
+static const io_e *adc_pins;
+static uint8_t adc_pin_cnt;
+static uint8_t dtc_channel_cnt;
+static bool initialized = false;
+
+static inline void adc_enable_and_start_conversion(void)
+{
+    ADC10CTL0 |= ENC + ADC10SC;
+}
+
+void adc_init(void)
+{
+    ASSERT(!initialized);
+    adc_pins = io_adc_pins(&adc_pin_cnt);
+
+    uint8_t adc10ae0 = 0;
+    uint8_t last_idx = 0;
+    for (uint8_t i = 0; i < adc_pin_cnt; i++) {
+        const uint8_t pin_idx = io_to_adc_idx(adc_pins[i]);
+        const uint8_t pin_bit = 1 << pin_idx;
+        adc10ae0 += pin_bit;
+        if (pin_idx > last_idx) {
+            last_idx = pin_idx;
+        }
+    }
+    const uint16_t inch = last_idx << 12;
+
+    /* inch: Select channels (last channel when CONSEQ_1)
+     * ADC10DIV_7: Clock division (higher means slower)
+     * CONSEQ_1: Sequence of channels
+     * SHS_0: ADC10SC bit starts conversion
+     * ADC10SSEL_1: ACLK as clock source (Slow) */
+    ADC10CTL1 = inch + ADC10DIV_7 + CONSEQ_1 + SHS_0 + ADC10SSEL_1;
+
+    /* ADC10ON: Enable
+     * SREF_0: Voltage reference (VCC and VSS)
+     * ADC10SHT_3: 64 * ADC10CLK sample and hold time (better readings?)
+     * MSC: Multiple sample conversion
+     * ADC10IE: Enable interrupt */
+    ADC10CTL0 = ADC10ON + SREF_0 + ADC10SHT_2 + MSC + ADC10IE;
+
+    // Enable ADC pins
+    ADC10AE0 = adc10ae0;
+
+    /* Use data transfer controller (DTC) to transfer data DMA-style from
+     * the sampled channels and interrupt afterwards. Note, CONSEQ_1 iterates
+     * the channels contiguously from last idx to 0. */
+    dtc_channel_cnt = last_idx + 1;
+    ADC10DTC0 = ADC10CT;
+    ADC10DTC1 = dtc_channel_cnt;
+    ADC10SA = (uint16_t)adc_dtc_block;
+
+    adc_enable_and_start_conversion();
+
+    initialized = true;
+}
+
+INTERRUPT_FUNCTION(ADC10_VECTOR) isr_adc10(void)
+{
+    for (uint8_t i = 0; i < dtc_channel_cnt; i++) {
+        // DTC writes the channel samples in opposite order
+        adc_dtc_block_cache[i] = adc_dtc_block[dtc_channel_cnt - 1 - i];
+    }
+    adc_enable_and_start_conversion();
+}
+
+void adc_get_channel_values(adc_channel_values_t values)
+{
+    /* For reason unclear to me, it's not enough to disable local ADC interrupt
+     * here as then ADC stops working after a while, so as a workaround disable
+     * interrupts globally. */
+    _disable_interrupts();
+    for (uint8_t i = 0; i < adc_pin_cnt; i++) {
+        const uint8_t channel_idx = io_to_adc_idx(adc_pins[i]);
+        values[channel_idx] = adc_dtc_block_cache[channel_idx];
+    }
+    _enable_interrupts();
+}

--- a/src/drivers/adc.h
+++ b/src/drivers/adc.h
@@ -1,0 +1,14 @@
+#ifndef ADC_H
+#define ADC_H
+
+// ADC driver sampling the values of the ADC assigned IO pins (see io.c)
+
+#include <stdint.h>
+
+#define ADC_CHANNEL_COUNT (8u)
+typedef uint16_t adc_channel_values_t[ADC_CHANNEL_COUNT];
+
+void adc_init(void);
+void adc_get_channel_values(adc_channel_values_t values);
+
+#endif // ADC_H

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -135,6 +135,13 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
                                     IO_OUT_LOW },
 };
 
+static const io_e io_adc_pins_arr[] = { IO_LINE_DETECT_FRONT_LEFT,
+                                        IO_LINE_DETECT_BACK_LEFT, 
+                                        IO_LINE_DETECT_FRONT_RIGHT,
+                                        IO_LINE_DETECT_BACK_RIGHT
+};
+
+
 // initialize all pins
 void io_init(void)
 {
@@ -323,4 +330,17 @@ INTERRUPT_FUNCTION(PORT2_VECTOR) isr_port_2(void)
     for (io_generic_e io = IO_20; io <= IO_27; io++) {
         io_isr(io);
     }
+}
+
+const io_e *io_adc_pins(uint8_t *cnt)
+{
+    *cnt = ARRAY_SIZE(io_adc_pins_arr);
+    return io_adc_pins_arr;
+}
+
+uint8_t io_to_adc_idx(io_e io)
+{
+    // Only pins on port 1 supports ADC
+    ASSERT(io_port(io) == IO_PORT1);
+    return io_pin_idx(io);
 }

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -109,5 +109,7 @@ void io_deconfigure_interrupt(io_e io);
 void io_enable_interrupt(io_e io);
 void io_disable_interrupt(io_e io);
 
+const io_e *io_adc_pins(uint8_t *cnt);
+uint8_t io_to_adc_idx(io_e io);
 
 #endif

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -28,7 +28,8 @@ static inline void init_clocks()
      * SMCLK: Subsystem master clock drives some peripherals */
     // BCSCTL2 default
 
-    // Select the internal Very Low Frequency oscillator (VLO) as ACLK source
+    // Select the internal Very Low Frequency oscillator (VLO) as ACLK source 
+    // (use for adc line sensor inputs)
     BCSCTL3 = LFXT1S_2;
 }
 static inline void watchdog_setup(void)

--- a/src/drivers/qre1113.c
+++ b/src/drivers/qre1113.c
@@ -1,0 +1,24 @@
+#include "qre1113.h"
+#include <stdbool.h>
+#include "io.h"
+#include "adc.h"
+#include "../common/assert_handler.h"
+
+
+static bool initialized = false;
+void qre1113_init(void)
+{
+    ASSERT(!initialized);
+    adc_init();
+    initialized = true;
+}
+
+void qre1113_get_voltages(struct qre1113_voltages *voltages)
+{
+    adc_channel_values_t values;
+    adc_get_channel_values(values);
+    voltages->front_left = values[io_to_adc_idx(IO_LINE_DETECT_FRONT_LEFT)];
+    voltages->front_right = values[io_to_adc_idx(IO_LINE_DETECT_FRONT_RIGHT)];
+    voltages->back_left = values[io_to_adc_idx(IO_LINE_DETECT_BACK_LEFT)];
+    voltages->back_right = values[io_to_adc_idx(IO_LINE_DETECT_BACK_RIGHT)];
+}

--- a/src/drivers/qre1113.h
+++ b/src/drivers/qre1113.h
@@ -1,0 +1,19 @@
+#ifndef QRE1113_H
+#define QRE1113_H
+
+// Driver for retrieving the voltage output from the line sensors QRE1113
+
+#include <stdint.h>
+
+struct qre1113_voltages
+{
+    uint16_t front_left;
+    uint16_t front_right;
+    uint16_t back_left;
+    uint16_t back_right;
+};
+
+void qre1113_init(void);
+void qre1113_get_voltages(struct qre1113_voltages *voltages);
+
+#endif // QRE1113_H

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -12,6 +12,7 @@
 #include <msp430.h>
 #include "../app/drive.h"
 #include "../drivers/adc.h"
+#include "../drivers/qre1113.h"
 
 SUPPRESS_UNUSED
 static void test_setup(void)
@@ -310,6 +311,21 @@ static void test_adc(void)
         for (uint8_t i = 0; i < ADC_CHANNEL_COUNT; i++) {
             TRACE("ADC ch %u: %u", i, values[i]);
         }
+        BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_qre1113(void)
+{
+    test_setup();
+    trace_init();
+    qre1113_init();
+    struct qre1113_voltages voltages = { 0, 0, 0, 0 };
+    while (1) {
+        qre1113_get_voltages(&voltages);
+        TRACE("Voltages fl %u fr %u bl %u br %u", voltages.front_left, voltages.front_right,
+                                                  voltages.back_left, voltages.back_right);
         BUSY_WAIT_ms(1000);
     }
 }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -11,6 +11,7 @@
 #include "../drivers/tb6612fng.h"
 #include <msp430.h>
 #include "../app/drive.h"
+#include "../drivers/adc.h"
 
 SUPPRESS_UNUSED
 static void test_setup(void)
@@ -295,6 +296,22 @@ static void test_assert_motors(void)
     BUSY_WAIT_ms(3000);
     ASSERT(0);
     while(0) { }
+}
+
+SUPPRESS_UNUSED
+static void test_adc(void)
+{
+    test_setup();
+    trace_init();
+    adc_init();
+    while (1) {
+        adc_channel_values_t values;
+        adc_get_channel_values(values);
+        for (uint8_t i = 0; i < ADC_CHANNEL_COUNT; i++) {
+            TRACE("ADC ch %u: %u", i, values[i]);
+        }
+        BUSY_WAIT_ms(1000);
+    }
 }
 
 int main()

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -13,6 +13,7 @@
 #include "../app/drive.h"
 #include "../drivers/adc.h"
 #include "../drivers/qre1113.h"
+#include "../app/line.h"
 
 SUPPRESS_UNUSED
 static void test_setup(void)
@@ -326,6 +327,18 @@ static void test_qre1113(void)
         qre1113_get_voltages(&voltages);
         TRACE("Voltages fl %u fr %u bl %u br %u", voltages.front_left, voltages.front_right,
                                                   voltages.back_left, voltages.back_right);
+        BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_line(void)
+{
+    test_setup();
+    trace_init();
+    line_init();
+    while (1) {
+        TRACE("Line %u", line_to_string(line_get()));
         BUSY_WAIT_ms(1000);
     }
 }


### PR DESCRIPTION
Sumo has 4 line sensors that give a voltage based on the light intesity infront of them, making it possible to detect the white boundary of the sumobot platform. Create an ADC driver to sample these voltages. Configure an ADC10 peripheral to sample these sequence of channels continuously. Interrupt each time the channel has been sampled and cache the values, and then start the next round. Reduce CPU involvement by using DMA and a slow clock ACLK.